### PR TITLE
Add stylesheet for icons

### DIFF
--- a/app/assets/stylesheets/modules/_payment_icon.scss
+++ b/app/assets/stylesheets/modules/_payment_icon.scss
@@ -1,0 +1,7 @@
+$data-svg-payment-method-bitcoin: asset-url("payment_icons/bitcoin.svg");
+$data-svg-payment-method-litecoin: asset-url("payment_icons/litecoin.svg");
+$data-svg-payment-method-dogecoin: asset-url("payment_icons/dogecoin.svg");
+
+.ico-payment-method--bitcoin { background-image: $data-svg-payment-method-bitcoin; background-size: 56px 36px; }
+.ico-payment-method--litecoin { background-image: $data-svg-payment-method-litecoin; background-size: 56px 36px; }
+.ico-payment-method--dogecoin { background-image: $data-svg-payment-method-dogecoin; background-size: 56px 36px; }

--- a/app/assets/stylesheets/modules/_payment_icon.scss
+++ b/app/assets/stylesheets/modules/_payment_icon.scss
@@ -1,7 +1,5 @@
-$data-svg-payment-method-bitcoin: asset-url("payment_icons/bitcoin.svg");
-$data-svg-payment-method-litecoin: asset-url("payment_icons/litecoin.svg");
-$data-svg-payment-method-dogecoin: asset-url("payment_icons/dogecoin.svg");
+$icon-size: 56px 36px;
 
-.ico-payment-method--bitcoin { background-image: $data-svg-payment-method-bitcoin; background-size: 56px 36px; }
-.ico-payment-method--litecoin { background-image: $data-svg-payment-method-litecoin; background-size: 56px 36px; }
-.ico-payment-method--dogecoin { background-image: $data-svg-payment-method-dogecoin; background-size: 56px 36px; }
+.ico-payment-method--bitcoin { background-image: asset-url("payment_icons/bitcoin.svg"); background-size: $icon-size }
+.ico-payment-method--litecoin { background-image: asset-url("payment_icons/litecoin.svg"); background-size: $icon-size }
+.ico-payment-method--dogecoin { background-image: asset-url("payment_icons/dogecoin.svg"); background-size: $icon-size }


### PR DESCRIPTION
Adds a stylesheet for use in the Shopify admin. When new logos are added, a line should be added here with the following syntax:
```scss
.ico-payment-method--<brand_name> { background-image: asset-url("payment_icons/<brand_name>.svg"); background-size: $icon-size }
```

This file is imported into the assets folder the same way the icons are, using the existing Rails engine. Theses styles will be used in the admin in the payment settings to select which card logos you want to display on checkout. A follow up PR will be added to Shopify to include this file as a Sass module in the main styles file.

@girasquid @andrewpaliga for review