### PR TITLE
Add a method for returning the group keys and labels

### DIFF
--- a/app/models/payment_icon.rb
+++ b/app/models/payment_icon.rb
@@ -1,6 +1,14 @@
 class PaymentIcon < FrozenRecord::Base
   self.base_path = File.expand_path('../../db/', __dir__)
 
+  GROUPS = {
+      credit_cards: 'Credit cards',
+      cryptocurrencies: 'Digital currencies',
+      bank_transfers: 'Bank transfers',
+      wallets: 'Digital wallets',
+      other: 'Other'
+    }
+
   def path
     "payment_icons/#{name}.svg"
   end

--- a/db/payment_icons.yml
+++ b/db/payment_icons.yml
@@ -41,7 +41,7 @@
 -
   name: boleto
   label: Boleto
-  group: bank_transfers
+  group: other
 -
   name: dankort
   label: Dankort


### PR DESCRIPTION
Adds a constant listing all groups and gives them a label. Will be used by a later Shopify PR. I wasn't too sure about the labels, so please tell me if there is something better.

![payment-methods-labels](https://cloud.githubusercontent.com/assets/3300109/10921827/b5583838-8245-11e5-8352-28b9a0013f4e.png)

@andrewpaliga @ivanfer for review