### PR TITLE
Precompile assets seperately

### DIFF
--- a/lib/payment_icons/engine.rb
+++ b/lib/payment_icons/engine.rb
@@ -1,5 +1,9 @@
 module PaymentIcons
   class Engine < ::Rails::Engine
     isolate_namespace PaymentIcons
+
+    initializer "payment_icons.assets.precompile" do |app|
+      app.config.assets.precompile += %w(*.svg)
+    end
   end
 end


### PR DESCRIPTION
Since the assets are never directly referenced in the Shopify app, they are never precompiled by the assets pipeline. This PR will ensure that all svgs are precompiled. This fixes this exceptions which I was getting on a Shopify branch:

```
Sprockets::Rails::Helper::AssetNotPrecompiled - Asset was not declared to be precompiled in production.
Add `Rails.application.config.assets.precompile += %w( payment_icons/visa.svg )` to `config/initializers/assets.rb` and restart your server:
  lib/patches/supress_precompiled_errors.rb:15:in `raise_unless_precompiled_asset'
```
@andrewpaliga @girasquid for review.

http://edgeguides.rubyonrails.org/engines.html#separate-assets-precompiling