### PR TITLE
Rename Paypal to PayPal

### DIFF
--- a/db/payment_icons.yml
+++ b/db/payment_icons.yml
@@ -72,7 +72,7 @@
   group: bank_transfers
 -
   name: paypal
-  label: Paypal
+  label: PayPal
   group: wallets
 -
   name: sofort


### PR DESCRIPTION
Pretty straightforward. PayPal is the correct label.

@WilsonChiang @bdewater for review