### PR TITLE
The Sass function now lives into it's own namespace:

### DIFF
--- a/app/assets/stylesheets/payment_icons/_payment_icons.scss
+++ b/app/assets/stylesheets/payment_icons/_payment_icons.scss
@@ -1,3 +1,19 @@
+$payment-icon--height: 24px;
+$duration--slowest: 0.5s;
+$easing--spring: cubic-bezier(0.3, 0, 0, 1);
+
+.payment-icon {
+  display: inline-block;
+  width: 38px;
+  height: $payment-icon--height;
+  transition: opacity $duration--slowest $easing--spring;
+  -webkit-backface-visibility: hidden;
+
+  .blank-slate & {
+    vertical-align: middle;
+  }
+}
+
 @each $svg-name, $class-name in payment-icons() {
   .payment-icon--#{$class-name} {
     background-image: image-url("payment_icons/#{$svg-name}.png");

--- a/lib/sass_functions/payment_icons.rb
+++ b/lib/sass_functions/payment_icons.rb
@@ -1,17 +1,23 @@
 # frozen_string_literal: true
 require 'sass'
 
-module Sass::Script::Functions
-  include Sass::Script::Value::Helpers
+module SassFunctions
+  module PaymentIcons
+    def payment_icons
+      pattern = ::PaymentIcons::Engine.root.join('app', 'assets', 'images', 'payment_icons', '*.svg')
+      icons = Dir.glob(pattern).map do |icon_path|
+        icon_name = File.basename(icon_path, '.svg')
+        svg_name = Sass::Script::Value::String.new(icon_name)
+        class_name = Sass::Script::Value::String.new(icon_name.dasherize)
 
-  def payment_icons
-    pattern = ::PaymentIcons::Engine.root.join('app', 'assets', 'images', 'payment_icons', '*.svg')
-    icons = Dir.glob(pattern).map do |icon_path|
-      icon_name = File.basename(icon_path, '.svg')
+        Sass::Script::Value::List.new([svg_name, class_name], :space)
+      end
 
-      list(quoted_string(icon_name), quoted_string(icon_name.dasherize), :space)
+      Sass::Script::Value::List.new(icons, :space)
     end
-
-    list(icons, :space)
   end
+end
+
+module Sass::Script::Functions
+  include SassFunctions::PaymentIcons
 end


### PR DESCRIPTION
- The previous implementation worked perfectly for the regular Sass Engine, however it would not work for other engines such as SassC
- The goal of this PR is to nest the `payment_icons` method into its own namespace that follows rails convention for autoloading, so that the host application can include it wherever it wants
- The Sass methods helpers (`quoted_string`, `list`...) were very convenient, but other implementation of sass have issue when a custom function includes `Sass::Script::Value::Helpers`

@AnthonyClark @joshnuss 