### PR TITLE
Add trustly to the payment_icons.yml where it was missing

### DIFF
--- a/db/payment_icons.yml
+++ b/db/payment_icons.yml
@@ -266,3 +266,7 @@
   name: apple_pay
   label: Apple Pay
   group: wallets
+-
+  name: trustly
+  label: Trustly
+  group: other


### PR DESCRIPTION
This icon was initially added in: https://github.com/activemerchant/payment_icons/commit/0fa0ac637cbbcd9d08f9cb726ef821f2a049230b

Icon and yml removed in: https://github.com/activemerchant/payment_icons/commit/6c131b26cc84b92834be612fe97f32411dcc8852

Icon added without yml in: https://github.com/activemerchant/payment_icons/commit/89a5641ef9c6db6d625e5f5088b3ecda65404d22

@Edouard-chin 
