### PR TITLE
Do not compile all SVG of all the folders

### DIFF
--- a/app/assets/config/payment_icons/manifest.js
+++ b/app/assets/config/payment_icons/manifest.js
@@ -1,0 +1,1 @@
+//= link_tree ../../images

--- a/lib/payment_icons/engine.rb
+++ b/lib/payment_icons/engine.rb
@@ -3,7 +3,7 @@ module PaymentIcons
     isolate_namespace PaymentIcons
 
     initializer "payment_icons.assets.precompile" do |app|
-      app.config.assets.precompile += %w(*.svg *.scss)
+      app.config.assets.precompile += %w(payment_icons/manifest.js)
     end
   end
 end


### PR DESCRIPTION
When you add `*.svg` to `Rails.application.config.assets.precompile` you are telling sprockets to look for that extension in all the folders that are inside the its load paths. This means that it will compile all the SVGs from inside all the modules inside the node_modules.

In Shopify core this means 60 seconds (half of the total time in my machine) spent building files that are not going to be used.

Instead of telling sprockets to look for all the SVGs we are now telling sprockets to compiles all the images in this gem, that is what we wanted to do.

Before this change:

```
$ time bin/rake assets:precompile
real	1m52.832s
user	1m29.360s
sys	0m19.873s
```

After this change:

```
$ time bin/rake assets:precompile
real	1m0.179s
user	0m43.844s
sys	0m8.682s
```