### PR TITLE
Add 'no bitmaps' to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,8 +1,8 @@
 ** Checklist **
 - [ ] All icons include `width="38" height="24"` in their attributes
 - [ ] All icons have solid white backgrounds
-- [ ] All icons have a a `viewBox` attribute
-- [ ] All fonts have been converted to paths
+- [ ] All icons have a `viewBox` attribute
+- [ ] All icons have no embedded fonts (convert these to paths) or bitmaps
 - [ ] All icons have a corresponding entry in `db/payment_icons.yml`
 - [ ] I am confident that all icons are clear and easy to read/understand
 


### PR DESCRIPTION
Embedding a PNG defeats the purpose of vector graphics, and base64 encoding adds a 33% overhead as well.