### PR TITLE
Add test to make sure every record has a corresponding SVG file

### DIFF
--- a/test/unit/payment_icon_test.rb
+++ b/test/unit/payment_icon_test.rb
@@ -11,7 +11,16 @@ class PaymentIconTest < ActiveSupport::TestCase
   end
 
   test '#path returns path within app/assets/images' do
-    visa = PaymentIcon.where(name: 'visa').first
-    assert_equal 'payment_icons/visa.svg', visa.path
+    PaymentIcon.all.each do |icon|
+      assert_equal "payment_icons/#{icon.name}.svg", icon.path
+    end
+  end
+
+  test 'Every payment icon record has a corresponding SVG file' do
+    ICONS_DIRECTORY = Rails.root.join("..", "..", "app/assets/images/payment_icons")
+
+    PaymentIcon.all.each do |icon|
+      assert File.exist?(ICONS_DIRECTORY.join("#{icon.name}.svg"))
+    end
   end
 end


### PR DESCRIPTION
This PR adds a test to make sure every entry in the [`payment_icons.yml`](https://github.com/activemerchant/payment_icons/blob/master/db/payment_icons.yml) file has a corresponding SVG file in the [`payment_icons`](https://github.com/activemerchant/payment_icons/tree/master/app/assets/images/payment_icons) assets folder.

It also improves an existing test by looping over entry to make sure `#path` returns the appropriate path.