### PR TITLE
Add viewBox requirement in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ To add a new payment method icon to this repository:
     - 38 by 24 pixels
     - Solid white background
     - 1 pixel wide solid grey border
+    - `viewBox="0 0 38 24"` attribute on the root `<svg>` tag
     - `role="img"` attribute on the root `<svg>` tag
     - `aria-labelledby` attribute on the root `<svg>` tag, equal to `pi-` + the name of your icon
     - `<title>` tag containing the label of your icon, with an `id` attribute equal to `pi-` + the name of your icon
@@ -46,7 +47,7 @@ To add a new payment method icon to this repository:
     Here's a template to get started (don't forget to replace `your-icon`):
 
     ```
-    <svg xmlns="http://www.w3.org/2000/svg" role="img" width="38" height="24" aria-labelledby="pi-your-icon">
+    <svg xmlns="http://www.w3.org/2000/svg" role="img" viewBox="0 0 38 24" width="38" height="24" aria-labelledby="pi-your-icon">
       <title id="pi-your-icon">Your Icon</title>
       <path opacity=".07" d="M35 0H3C1.3 0 0 1.3 0 3v18c0 1.7 1.4 3 3 3h32c1.7 0 3-1.3 3-3V3c0-1.7-1.4-3-3-3z"/>
       <path fill="#fff" d="M35 1c1.1 0 2 .9 2 2v18c0 1.1-.9 2-2 2H3c-1.1 0-2-.9-2-2V3c0-1.1.9-2 2-2h32"/>


### PR DESCRIPTION
This PR adds a requirement for the `viewBox` attribute on the root `<svg>` tag.