### PR TITLE
Remove rails upperbound and test against latest release and rails HEAD

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,16 @@ rvm:
 
 gemfile:
   - gemfiles/rails-5-0.gemfile
-  - gemfiles/rails-5-1.gemfile
-  - gemfiles/rails-5-2.gemfile
+  - gemfiles/rails-latest-release.gemfile
+  - gemfiles/rails-edge.gemfile
+
+matrix:
+  exclude:
+    - rvm: 2.3.7
+      gemfile: gemfiles/rails-edge.gemfile
+    - rvm: 2.4.4
+      gemfile: gemfiles/rails-edge.gemfile
+
 
 notifications:
 email: false

--- a/gemfiles/rails-edge.gemfile
+++ b/gemfiles/rails-edge.gemfile
@@ -2,4 +2,4 @@ source "https://rubygems.org"
 
 gemspec path: '..'
 
-gem 'rails', '~> 5.1.0'
+gem 'rails', github: 'rails'

--- a/gemfiles/rails-latest-release.gemfile
+++ b/gemfiles/rails-latest-release.gemfile
@@ -2,4 +2,4 @@ source "https://rubygems.org"
 
 gemspec path: '..'
 
-gem 'rails', github: 'rails', branch: '5-2-stable'
+gem 'rails'

--- a/payment_icons.gemspec
+++ b/payment_icons.gemspec
@@ -16,8 +16,8 @@ Gem::Specification.new do |s|
   s.test_files = Dir['test/**/*']
 
   s.add_dependency 'frozen_record'
-  s.add_dependency 'railties', '>= 5.0', '< 6.0'
+  s.add_dependency 'railties', '>= 5.0'
   s.add_dependency 'sass'
 
-  s.add_development_dependency('rails', '>= 5.0', '< 6.0')
+  s.add_development_dependency('rails', '>= 5.0')
 end


### PR DESCRIPTION
We can remove Rails upperbound and test against edge. This would help app developers to update to latest Rails without updating this gem.

Also currently without having any Rails version conditional code we are testing against every minor version. We can structure this better by testing against lowest version, latest release and edge.


