### PR TITLE
Make sure images are base64-encoded PNGs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ All icon contributions must follow the guidelines below. The **markup** guidelin
   - `id` attribute with the value `pi-` + the name of your icon, (same as the `aria-labelledby`)
   - Inner text containing the label of your icon
 - The `<svg>` must use vector graphics, i.e. `path`, `rect`, etc.
-  - Nested `<image>` or `<img>` elements will not be accepted.
+  - Nested `<image>` or `<img>` elements will only be accepted if they contain base64-encoded PNG image data. Paths to image files will not be accepted.
   - Embedded fonts or bitmaps will not be accepted.
 - All `id` attributes start with `pi-`.
 

--- a/test/unit/payment_icon_test.rb
+++ b/test/unit/payment_icon_test.rb
@@ -103,4 +103,21 @@ class PaymentIconTest < ActiveSupport::TestCase
         message: "The '#{payment_type}' SVG file should have a aria-labelledby='#{ICON_ID_PREFIX}#{payment_type}' attribute on the root <svg> node"
     end
   end
+
+  test 'Payment icon SVGs with <img> or <image> tags base64-encode PNG image data' do
+    SVG_PAYMENT_TYPES.each do |payment_type, svg|
+      document = Nokogiri::XML.parse(svg)
+
+      image_nodes = []
+      image_nodes << document.search("img")
+      image_nodes << document.search("image")
+      image_nodes.flatten!.uniq!
+
+      image_nodes.each do |image_node|
+        xlink_href_content = image_node['xlink:href']
+        error_message = "Expected image tag to contain base64 encoded PNG, found '#{xlink_href_content.truncate(50)}' instead"
+        assert xlink_href_content.start_with?('data:image/png;base64'), error_message
+      end
+    end
+  end
 end


### PR DESCRIPTION
Fix https://github.com/activemerchant/payment_icons/issues/174 by making sure `<image>`/`<img>` tags encode image data as a base64-encoded PNG.

### Failure example
**SVG with path to image**
```
<svg viewBox="0 0 38 24" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="38" height="24" role="img" aria-labelledby="pi-swish">
    <title id="pi-swish">Swish</title>
    <path fill="#fff" stroke="#000" stroke-width="1.5" d="M-6-2h50v28H-6z" />
    <image overflow="visible" width="2126" height="2104" xlink:href="../../../../../../../../Downloads/BBL-BS-E.jpg" transform="matrix(.24 0 0 .24 -8050.3 -8138.5)" />
</svg>
```

**Test result**
```
# Running:

.....F

Failure:
PaymentIconTest#test_Payment_icon_SVGs_with_<img>_or_<image>_tags_base64-encode_PNG_image_data [/Users/maximevaillancourt/src/github.com/maximevaillancourt/payment_icons/test/unit/payment_icon_test.rb:119]:
Expected image tag to contain base64 encoded PNG, found '../../../../../../../../Downloads/BBL-BS-E.jpg' instead
```