### PR TITLE
Add manifest.js in /config directory

### DIFF
--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,1 +1,0 @@
-//= link_tree ../images

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,0 +1,1 @@
+//= link_tree ../images

--- a/app/assets/config/payment_icons/manifest.js
+++ b/app/assets/config/payment_icons/manifest.js
@@ -1,0 +1,1 @@
+//= link_tree ../../images

--- a/app/assets/config/payment_icons/manifest.js
+++ b/app/assets/config/payment_icons/manifest.js
@@ -1,1 +1,0 @@
-//= link_tree ../../images


### PR DESCRIPTION
** Purpose **

While making a release, `shipit` triggers [an error](https://travis-ci.org/activemerchant/payment_icons) when it's trying to build :

```
Expected to find a manifest file in `app/assets/config/manifest.js` (Sprockets::Railtie::ManifestNeededError)
But did not, please create this file and use it to link any assets that need
to be rendered by your app:
```

I'm adding a new `manifest.js` file in the `config` directory and made adjustment to the directory path. I'm not sure if the old file located in `config/payment_icons` should be deleted or not but I left it there for the time being.