### PR TITLE
Downgrade sassc version to 2.1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ gemfile:
 
 matrix:
   exclude:
-    - rvm: 2.4.4
+    - rvm: 2.4.9
       gemfile: gemfiles/rails-edge.gemfile
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: ruby
-script: "bundle exec rake test"
+script: 'bundle exec rake test'
 sudo: false
 cache: bundler
 
 rvm:
-  - 2.4.4
+  - 2.4.9
   - 2.5.1
   - 2.6.2
 
@@ -17,7 +17,6 @@ matrix:
   exclude:
     - rvm: 2.4.4
       gemfile: gemfiles/rails-edge.gemfile
-
 
 notifications:
 email: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -120,7 +120,7 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.20.3, < 2.0)
     rake (12.3.3)
-    sassc (2.2.1)
+    sassc (2.1.0)
       ffi (~> 1.9)
     sassc-rails (2.1.0)
       railties (>= 4.0.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,7 @@ PATH
     payment_icons (1.3.3)
       frozen_record
       railties (>= 5.0)
-      sassc-rails (= 2.1.0)
+      sassc-rails
 
 GEM
   remote: https://rubygems.org/
@@ -122,7 +122,7 @@ GEM
     rake (12.3.3)
     sassc (2.2.1)
       ffi (~> 1.9)
-    sassc-rails (2.1.0)
+    sassc-rails (2.1.2)
       railties (>= 4.0.0)
       sassc (>= 2.0)
       sprockets (> 3.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,7 @@ PATH
     payment_icons (1.3.3)
       frozen_record
       railties (>= 5.0)
-      sassc-rails
+      sassc-rails (= 2.1.0)
 
 GEM
   remote: https://rubygems.org/
@@ -122,7 +122,7 @@ GEM
     rake (12.3.3)
     sassc (2.2.1)
       ffi (~> 1.9)
-    sassc-rails (2.1.2)
+    sassc-rails (2.1.0)
       railties (>= 4.0.0)
       sassc (>= 2.0)
       sprockets (> 3.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,7 @@ PATH
     payment_icons (1.3.3)
       frozen_record
       railties (>= 5.0)
-      sassc-rails
+      sassc-rails (~> 2.1.0)
 
 GEM
   remote: https://rubygems.org/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,7 @@ PATH
     payment_icons (1.3.3)
       frozen_record
       railties (>= 5.0)
-      sassc-rails (~> 2.1.0)
+      sassc-rails (= 2.1.0)
 
 GEM
   remote: https://rubygems.org/
@@ -122,7 +122,7 @@ GEM
     rake (12.3.3)
     sassc (2.2.1)
       ffi (~> 1.9)
-    sassc-rails (2.1.2)
+    sassc-rails (2.1.0)
       railties (>= 4.0.0)
       sassc (>= 2.0)
       sprockets (> 3.0)

--- a/payment_icons.gemspec
+++ b/payment_icons.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'frozen_record'
   s.add_dependency 'railties', '>= 5.0'
-  s.add_dependency 'sassc-rails'
+  s.add_dependency 'sassc-rails', '~>2.1.0'
 
   s.add_development_dependency('rails', '>= 5.0')
 end

--- a/payment_icons.gemspec
+++ b/payment_icons.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'frozen_record'
   s.add_dependency 'railties', '>= 5.0'
-  s.add_dependency 'sassc-rails', '2.1.0'
+  s.add_dependency 'sassc-rails'
 
   s.add_development_dependency('rails', '>= 5.0')
 end

--- a/payment_icons.gemspec
+++ b/payment_icons.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'frozen_record'
   s.add_dependency 'railties', '>= 5.0'
-  s.add_dependency 'sassc-rails'
+  s.add_dependency 'sassc-rails', '2.1.0'
 
   s.add_development_dependency('rails', '>= 5.0')
 end

--- a/payment_icons.gemspec
+++ b/payment_icons.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'frozen_record'
   s.add_dependency 'railties', '>= 5.0'
-  s.add_dependency 'sassc-rails', '~>2.1.0'
+  s.add_dependency 'sassc-rails', '2.1.0'
 
   s.add_development_dependency('rails', '>= 5.0')
 end


### PR DESCRIPTION
The goal of the PR is to resolve the build issue during the CI phase. In ShipIt, the build fails in Ruby 2.4.4 but not for other versions.

After discussing with other people, downgrading the `sassc` gem to 2.1.0 should fix the problem.

Previous PR for reference: https://github.com/activemerchant/payment_icons/pull/197