### PR TITLE
Remove png fallback

### DIFF
--- a/app/assets/stylesheets/payment_icons/_payment_icons.scss
+++ b/app/assets/stylesheets/payment_icons/_payment_icons.scss
@@ -16,7 +16,6 @@ $easing--spring: cubic-bezier(0.3, 0, 0, 1);
 
 @each $svg-name, $class-name in payment-icons() {
   .payment-icon--#{$class-name} {
-    background-image: image-url("payment_icons/#{$svg-name}.png");
     background-image: image-url("payment_icons/#{$svg-name}.svg"), none;
   }
 }


### PR DESCRIPTION
This PR removes the fallback we have to `png` files, which are generates automatically via sprockets and imagemagick. This causes a bunch of problems when adding new svg files (https://github.com/activemerchant/payment_icons/pull/212)

Also, currently a lot of the automatically generated png files are also not what we expect:

Visa - borders are not what they should be:
![visa-3bb9174d1b265b1206120577dee00e4f01f1dc76de6c859d45bfea50ae263a74](https://user-images.githubusercontent.com/2699745/70881973-a439b680-2011-11ea-9b39-8a37d18afca6.png)

Shopify Pay:
![shopify_pay](https://user-images.githubusercontent.com/2699745/70881993-b4519600-2011-11ea-8620-e43fee7d8312.png)

Swedbank - just a white rectangle:
![swedbank-d9eb3f1f8c62672db0bad3a558707821171f6ceb3c850988ba482b5276a4026d](https://user-images.githubusercontent.com/2699745/70882006-bb78a400-2011-11ea-9246-a7b6b16353d0.png)


SVG support is pretty [widespread](https://caniuse.com/#feat=svg), unless we want to support IE 6-8, I would like to propose to drop the png fallback for payment icons.

@AnotherJoSmith @unixcharles @tauthomas01 @douglas 