### PR TITLE
Temporarily remove ruby 2.4 from CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ sudo: false
 cache: bundler
 
 rvm:
-  - 2.4.4
   - 2.5.1
   - 2.6.2
 


### PR DESCRIPTION
Remove ruby 2.4 temporarly from travis CI in order to get builds passing. There seems to be a bug with ffi on ruby 2.4 with rails 5. More context in https://github.com/activemerchant/payment_icons/pull/212 and https://github.com/activemerchant/payment_icons/issues/217