### PR TITLE
Add 'allowed_push_host' to gemspec

### DIFF
--- a/payment_icons.gemspec
+++ b/payment_icons.gemspec
@@ -18,6 +18,10 @@ Gem::Specification.new do |s|
   s.add_dependency 'frozen_record'
   s.add_dependency 'railties', '>= 5.0'
   s.add_dependency 'sassc-rails'
+  
+  if s.respond_to?(:metadata)
+    s.metadata["allowed_push_host"] = 'https://rubygems.org'
+  end
 
   s.add_development_dependency('rails', '>= 5.0')
 end


### PR DESCRIPTION
The gem is missing the `allowed_push_host` metadata value to allow publishing to rubygems.org.

This PR adds the missing value.