### PR TITLE
Downgrade sassc-rail

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -120,7 +120,7 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.20.3, < 2.0)
     rake (12.3.3)
-    sassc (2.3.0)
+    sassc (2.2.1)
       ffi (~> 1.9)
     sassc-rails (2.1.2)
       railties (>= 4.0.0)


### PR DESCRIPTION
### Problem

`sassc` gem (2.3.0) is timing out while making a release.
I'm temporarily downgrading the version to see if it timeouts again.