### PR TITLE
Fix CI: Lock frozen_record dependency to 0.18.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -153,4 +153,4 @@ DEPENDENCIES
   rails (>= 5.0)
 
 BUNDLED WITH
-   2.0.2
+   2.1.4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -153,4 +153,4 @@ DEPENDENCIES
   rails (>= 5.0)
 
 BUNDLED WITH
-   2.1.4
+   2.0.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     payment_icons (1.4.5)
-      frozen_record
+      frozen_record (<= 0.18.0)
       railties (>= 5.0)
       sassc-rails
 
@@ -69,7 +69,7 @@ GEM
     crass (1.0.5)
     erubi (1.8.0)
     ffi (1.13.1)
-    frozen_record (0.17.0)
+    frozen_record (0.18.0)
       activemodel
     globalid (0.4.2)
       activesupport (>= 4.2.0)

--- a/payment_icons.gemspec
+++ b/payment_icons.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.files = Dir['{app,config,db,lib}/**/*', 'MIT-LICENSE', 'Rakefile', 'README.rdoc']
   s.test_files = Dir['test/**/*']
 
-  s.add_dependency 'frozen_record'
+  s.add_dependency 'frozen_record', '0.18.0'
   s.add_dependency 'railties', '>= 5.0'
   s.add_dependency 'sassc-rails'
   

--- a/payment_icons.gemspec
+++ b/payment_icons.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.files = Dir['{app,config,db,lib}/**/*', 'MIT-LICENSE', 'Rakefile', 'README.rdoc']
   s.test_files = Dir['test/**/*']
 
-  s.add_dependency 'frozen_record', '0.18.0'
+  s.add_dependency 'frozen_record', '<= 0.18.0'
   s.add_dependency 'railties', '>= 5.0'
   s.add_dependency 'sassc-rails'
   


### PR DESCRIPTION
## Context

Fixing this one since I have another PR open with CI failing https://github.com/activemerchant/payment_icons/pull/292 

The bug can be duplicated here if you follow the README instructions here https://github.com/rramsden/frozen-record-bug
I tracked the problem down to Activemodel version 5 (Rails 5.0) and the latest version of frozen_record being not compatible.

It seems [frozen_record](https://github.com/byroot/frozen_record) latest versions 0.19.0 and 0.19.1 have the following changeset introduced https://github.com/byroot/frozen_record/commit/de8db97bbcf07ca57e28411b9f8dd1b15d0fb079 which breaks Rails 5.0 causing the CI to fail (see https://github.com/activemerchant/payment_icons/pull/291)

For now, I've locked `frozen_record` gem version to `<= 0.18.0` since this version and previous don't have the same issues.