### PR TITLE
Release v1.4.6

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    payment_icons (1.4.5)
+    payment_icons (1.4.6)
       frozen_record (<= 0.18.0)
       railties (>= 5.0)
       sassc-rails

--- a/lib/payment_icons/version.rb
+++ b/lib/payment_icons/version.rb
@@ -1,3 +1,3 @@
 module PaymentIcons
-  VERSION = "1.4.5"
+  VERSION = "1.4.6"
 end


### PR DESCRIPTION
- Add LINE Pay, Rakuten Pay, Pay Easy, Softbank, and Yahoo Mobile icons (https://github.com/activemerchant/payment_icons/pull/301)
- Lock `frozen_record` dependency to fix CI (https://github.com/activemerchant/payment_icons/pull/301)

Ideally, we could also include https://github.com/activemerchant/payment_icons/pull/292 in this release.