### PR TITLE
Support frozen_record >= 0.19

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     payment_icons (1.4.7)
-      frozen_record (<= 0.18.0)
+      frozen_record
       railties (>= 5.0)
       sassc-rails
 
@@ -69,7 +69,7 @@ GEM
     crass (1.0.5)
     erubi (1.8.0)
     ffi (1.13.1)
-    frozen_record (0.18.0)
+    frozen_record (0.19.1)
       activemodel
     globalid (0.4.2)
       activesupport (>= 4.2.0)

--- a/gemfiles/rails-5-0.gemfile
+++ b/gemfiles/rails-5-0.gemfile
@@ -3,3 +3,4 @@ source "https://rubygems.org"
 gemspec path: '..'
 
 gem 'rails', '~> 5.0.0'
+gem 'frozen_record', '~> 0.18.0'

--- a/gemfiles/rails-edge.gemfile
+++ b/gemfiles/rails-edge.gemfile
@@ -3,3 +3,4 @@ source "https://rubygems.org"
 gemspec path: '..'
 
 gem 'rails', github: 'rails'
+gem 'frozen_record', '~> 0.19.0'

--- a/gemfiles/rails-latest-release.gemfile
+++ b/gemfiles/rails-latest-release.gemfile
@@ -3,3 +3,4 @@ source "https://rubygems.org"
 gemspec path: '..'
 
 gem 'rails'
+gem 'frozen_record', '~> 0.19.0'

--- a/payment_icons.gemspec
+++ b/payment_icons.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.files = Dir['{app,config,db,lib}/**/*', 'MIT-LICENSE', 'Rakefile', 'README.rdoc']
   s.test_files = Dir['test/**/*']
 
-  s.add_dependency 'frozen_record', '<= 0.18.0'
+  s.add_dependency 'frozen_record'
   s.add_dependency 'railties', '>= 5.0'
   s.add_dependency 'sassc-rails'
   


### PR DESCRIPTION
Fix support for frozen_record >= 0.19 so people using said verison of frozen_record can upgrade their payment_icons version to >= 1.4.7, which is currently impossible due to a dependency mismatch. 😞 https://github.com/activemerchant/payment_icons/pull/301#issuecomment-669625826
<img width="484" alt="Screen Shot 2020-08-06 at 10 09 38" src="https://user-images.githubusercontent.com/1557529/89480062-5f94a280-d7cf-11ea-9041-ecbe30149f4c.png">

Confirmed this change allows installation in repos with Rails 6 and frozen_record >= 0.19.