### PR TITLE
Release v1.4.8

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    payment_icons (1.4.7)
+    payment_icons (1.4.8)
       frozen_record
       railties (>= 5.0)
       sassc-rails

--- a/lib/payment_icons/version.rb
+++ b/lib/payment_icons/version.rb
@@ -1,3 +1,3 @@
 module PaymentIcons
-  VERSION = "1.4.7"
+  VERSION = "1.4.8"
 end


### PR DESCRIPTION
- Support frozen_record >= 0.19 (https://github.com/activemerchant/payment_icons/pull/304)
- Fix Pay Easy categorization (https://github.com/activemerchant/payment_icons/pull/306)

Let's merge https://github.com/activemerchant/payment_icons/pull/304 and https://github.com/activemerchant/payment_icons/pull/306 then rebase this PR and release v1.4.8.