### PR TITLE
Fix Pay Easy categorization

### DIFF
--- a/db/payment_icons.yml
+++ b/db/payment_icons.yml
@@ -648,7 +648,7 @@
 -
   name: pay_easy
   label: Pay Easy
-  group: wallets
+  group: other
 -
   name: softbank
   label: Softbank


### PR DESCRIPTION
Tiny follow-up to https://github.com/activemerchant/payment_icons/pull/277 to fix Pay Easy's categorization.

@tauthomas01 🙏 
