### PR TITLE
Update Travis CI rubies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,9 @@ dist: xenial
 os: linux
 
 rvm:
-  - 2.5.1
-  - 2.6.2
+  - 2.5.8
+  - 2.6.6
+  - 2.7.1
 
 gemfile:
   - gemfiles/rails-5-0.gemfile
@@ -15,7 +16,7 @@ gemfile:
 
 jobs:
   exclude:
-    - rvm: 2.4.4
+    - rvm: 2.7.1
       gemfile: gemfiles/rails-edge.gemfile
 
 notifications:


### PR DESCRIPTION
Bring the Ruby versions we use in Travis CI up to date and ensure we test against all non-EOL rubies.

Latest versions sourced from [ruby-lang.org/en/downloads/releases](https://www.ruby-lang.org/en/downloads/releases/).