### PR TITLE
Add pry development dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,6 +65,7 @@ GEM
       tzinfo (~> 1.1)
       zeitwerk (~> 2.2, >= 2.2.2)
     builder (3.2.4)
+    coderay (1.1.3)
     concurrent-ruby (1.1.7)
     crass (1.0.6)
     dedup (0.1.1)
@@ -92,6 +93,9 @@ GEM
     nio4r (2.5.3)
     nokogiri (1.10.10)
       mini_portile2 (~> 2.4.0)
+    pry (0.13.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
     rack (2.2.3)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
@@ -152,6 +156,7 @@ PLATFORMS
 
 DEPENDENCIES
   payment_icons!
+  pry
   rails (>= 5.0)
 
 BUNDLED WITH

--- a/payment_icons.gemspec
+++ b/payment_icons.gemspec
@@ -24,4 +24,5 @@ Gem::Specification.new do |s|
   end
 
   s.add_development_dependency('rails', '>= 5.0')
+  s.add_development_dependency('pry')
 end


### PR DESCRIPTION
Was surprised to see pry was not available. Quite useful, so I propose we add it to development dependencies.