### PR TITLE
Add no <style> tags test

### DIFF
--- a/test/unit/payment_icon_test.rb
+++ b/test/unit/payment_icon_test.rb
@@ -120,4 +120,16 @@ class PaymentIconTest < ActiveSupport::TestCase
       end
     end
   end
+
+  test 'Payment icon SVGs do not contain <style> tags' do
+    SVG_PAYMENT_TYPES.each do |payment_type, svg|
+      document = Nokogiri::XML.parse(svg)
+
+      style_nodes = []
+      style_nodes << document.search('style')
+      style_nodes.flatten!.uniq!
+
+      assert_predicate(style_nodes, :empty?, "Expected #{payment_type} SVG to not contain <style> tags.")
+    end
+  end
 end


### PR DESCRIPTION
Add a test to ensure we don't add SVGs with `<style>` tags. Note, _should_ allow inline styles.
<img width="1459" alt="Screen Shot 2020-09-06 at 12 59 14" src="https://user-images.githubusercontent.com/1557529/92318092-51da7300-f042-11ea-8bda-2be628924dbd.png">

Note, fails for some current SVGs as they have `<style>` tags. Maybe we should create a "legacy exceptions list". 🤔 

Enforces the following line in the [CONTRIBUTING.md](https://github.com/activemerchant/payment_icons/blob/3f02768f01beb6691d54e0d50c0e78e9296f879b/CONTRIBUTING.md).

> All styles should be inline. There should be no <style> tag unless it is absolutely necessary.

Resolves https://github.com/activemerchant/payment_icons/issues/179
Part of resolving https://github.com/activemerchant/payment_icons/issues/184