### PR TITLE
Release v1.5.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    payment_icons (1.5.1)
+    payment_icons (1.5.2)
       frozen_record
       railties (>= 5.0)
       sassc-rails

--- a/lib/payment_icons/version.rb
+++ b/lib/payment_icons/version.rb
@@ -1,3 +1,3 @@
 module PaymentIcons
-  VERSION = "1.5.1"
+  VERSION = "1.5.2"
 end


### PR DESCRIPTION
- Add mbway icon ([#298](https://github.com/activemerchant/payment_icons/pull/298))
- Remove hardcoded white background from elo icon ([#351](https://github.com/activemerchant/payment_icons/pull/351))
- Remove hardcoded white background from hiper, hipercard, and collector bank icons ([#355](https://github.com/activemerchant/payment_icons/pull/355))
- Remove hardcoded white background and add proper fill to mondido icon ([#358](https://github.com/activemerchant/payment_icons/pull/358))

Nothing breaking, clean release. 🚀 