### PR TITLE
[CI] Ruby 3.0.0-preview1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,16 @@ rvm:
   - 2.5.8
   - 2.6.6
   - 2.7.2
+  - 3.0.0-preview1
 
 gemfile:
   - gemfiles/rails-5-0.gemfile
   - gemfiles/rails-latest-release.gemfile
   - gemfiles/rails-edge.gemfile
+
+jobs:
+  allow_failures:
+    - rvm: 3.0.0-preview1
 
 notifications:
   email: false


### PR DESCRIPTION
⚠️ DO NOT MERGE ⚠️ 

Considering adding Ruby 3.0.0-preview1 as non-required CI as Ruby 3.0.0 will be releasing in December.

Seems https://github.com/rvm/rvm/pull/4987 added support for `3.0.0-preview1` but said change hasn't made it into an RVM release yet. 😭 