### PR TITLE
[CI] Remove Ruby 2.7.2 Rails edge exclusion

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,5 @@ gemfile:
   - gemfiles/rails-latest-release.gemfile
   - gemfiles/rails-edge.gemfile
 
-jobs:
-  exclude:
-    - rvm: 2.7.2
-      gemfile: gemfiles/rails-edge.gemfile
-
 notifications:
   email: false


### PR DESCRIPTION
Remove the exclusion for Ruby 2.7.2 + Rails edge CI. No reason to exclude said combination.