### PR TITLE
[CI] Ruby 3.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,12 @@ rvm:
   - 2.5.8
   - 2.6.6
   - 2.7.2
+  - 3.0.0
+
+jobs:
+  exclude:
+    - rvm: 3.0.0
+      gemfile: gemfiles/rails-5-0.gemfile
 
 gemfile:
   - gemfiles/rails-5-0.gemfile


### PR DESCRIPTION
Add Ruby 3.0.0, which was released on Christmas (Dec 25th) last year, as a CI target for all but Rails 5.

✨ https://www.ruby-lang.org/en/news/2020/12/25/ruby-3-0-0-released/ 🎄