### PR TITLE
Fix Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,6 @@
-version: 1
-update_configs:
-  - package_manager: 'ruby:bundler'
-    directory: '/'
-    update_schedule: 'live'
-    version_requirement_updates: 'auto'
-    default_labels:
-      - 'Gem upgrades'
+version: 2
+updates:
+  - package-ecosystem: "ruby"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
Fix Dependabot config to work with the current (GitHub) Dependabot (v2), which differs from the original (dependabot.com) Dependabot (v1). Seeing the following errors in GitHub settings. Revamped config according to [GitHub's docs](https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/enabling-and-disabling-version-updates#example-dependabotyml-file). 

```
The property '#/' did not contain a required property of 'updates'
The property '#/' contains additional properties ["update_configs"] outside of the schema when none are allowed
The property '#/version' value 1 did not match one of the following values: 2
```

Follow-up to https://github.com/activemerchant/payment_icons/pull/384.