### PR TITLE
Fix Rabbit LINE Pay icon label

### DIFF
--- a/db/payment_icons.yml
+++ b/db/payment_icons.yml
@@ -880,7 +880,7 @@
   group: wallets
 -
   name: rabbitlinepay
-  label: Rabbit Line Pay
+  label: Rabbit LINE Pay
   group: wallets
 -
   name: tescolotus


### PR DESCRIPTION
Quick fix for the Rabbit LINE Pay icon label, `LINE` was improperly capitalized as `Line`.