### PR TITLE
[CI] Remove Rails edge for Ruby 2.5 and 2.6

### DIFF
--- a/.github/workflows/ruby-ci.yml
+++ b/.github/workflows/ruby-ci.yml
@@ -26,11 +26,15 @@ jobs:
           - gemfiles/rails-latest-release.gemfile
           - gemfiles/rails-edge.gemfile
         exclude:
+          - version: 2.5
+            gemfile: gemfiles/rails-edge.gemfile
+          - version: 2.6
+            gemfile: gemfiles/rails-edge.gemfile
           - version: 3.0
             gemfile: gemfiles/rails-5-0.gemfile
     steps:
       - uses: actions/checkout@v2
-      
+
       - name: Set up Ruby ${{ matrix.version }}
         uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
Rails edge (master) now requires Ruby >= 2.7. ([CI failure](https://github.com/activemerchant/payment_icons/runs/1851501766))
<img width="928" alt="Screen Shot 2021-02-08 at 11 22 20" src="https://user-images.githubusercontent.com/1557529/107169348-f94c3f00-6a00-11eb-93b5-6a6fe950cf7e.png">
