### PR TITLE
Revert "Release v1.5.7"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    payment_icons (1.5.7)
+    payment_icons (1.5.6)
       frozen_record
       railties (>= 5.0)
       sassc-rails

--- a/lib/payment_icons/version.rb
+++ b/lib/payment_icons/version.rb
@@ -1,3 +1,3 @@
 module PaymentIcons
-  VERSION = "1.5.7"
+  VERSION = "1.5.6"
 end


### PR DESCRIPTION
Reverts activemerchant/payment_icons#403

Need to fix CI (https://github.com/activemerchant/payment_icons/pull/404). Recent Rails change made Ruby >= 2.7 required for Rails master.

Should have rebased the release PR before merging for up to date CI. 🙇‍♂️ 