### PR TITLE
Release v1.5.7

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    payment_icons (1.5.6)
+    payment_icons (1.5.7)
       frozen_record
       railties (>= 5.0)
       sassc-rails

--- a/lib/payment_icons/version.rb
+++ b/lib/payment_icons/version.rb
@@ -1,3 +1,3 @@
 module PaymentIcons
-  VERSION = "1.5.6"
+  VERSION = "1.5.7"
 end


### PR DESCRIPTION
Second attempt at releasing v1.5.7. Needed to revert the original, approved release PR (https://github.com/activemerchant/payment_icons/pull/403) due to a CI issue (https://github.com/activemerchant/payment_icons/pull/404).

- Added QR PromptPay icon ([#386](https://github.com/activemerchant/payment_icons/pull/386))
- Added RCS icon ([#392](https://github.com/activemerchant/payment_icons/pull/392))
- Added Bangkok Bank, Kasikorn Bank, Krung Thai Bank, Thanachart Bank, UOB Thai, Big C, Boost, EC Pay, Maybank QR Pay, M Cash, Rabbit LINE Pay, Tesco Lotus, Touch n Go icons ([#393](https://github.com/activemerchant/payment_icons/pull/393), [#397](https://github.com/activemerchant/payment_icons/pull/397))
- Added PayMe icon ([#399](https://github.com/activemerchant/payment_icons/pull/399))
- Replaced Travis with GitHub Actions ([#390](https://github.com/activemerchant/payment_icons/pull/390), [#400](https://github.com/activemerchant/payment_icons/pull/400))
