### PR TITLE
Release v1.6.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    payment_icons (1.5.8)
+    payment_icons (1.6.0)
       frozen_record
       railties (>= 5.0)
       sassc-rails
@@ -72,9 +72,9 @@ GEM
     coderay (1.1.3)
     concurrent-ruby (1.1.8)
     crass (1.0.6)
-    dedup (0.1.3)
+    dedup (0.1.2)
     erubi (1.10.0)
-    ffi (1.14.2)
+    ffi (1.13.1)
     frozen_record (0.21.1)
       activemodel
       dedup

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    payment_icons (1.5.7)
+    payment_icons (1.5.8)
       frozen_record
       railties (>= 5.0)
       sassc-rails
@@ -72,9 +72,9 @@ GEM
     coderay (1.1.3)
     concurrent-ruby (1.1.8)
     crass (1.0.6)
-    dedup (0.1.2)
+    dedup (0.1.3)
     erubi (1.10.0)
-    ffi (1.13.1)
+    ffi (1.14.2)
     frozen_record (0.21.1)
       activemodel
       dedup

--- a/lib/payment_icons/version.rb
+++ b/lib/payment_icons/version.rb
@@ -1,3 +1,3 @@
 module PaymentIcons
-  VERSION = "1.5.7"
+  VERSION = "1.5.8"
 end

--- a/lib/payment_icons/version.rb
+++ b/lib/payment_icons/version.rb
@@ -1,3 +1,3 @@
 module PaymentIcons
-  VERSION = "1.5.8"
+  VERSION = "1.6.0"
 end


### PR DESCRIPTION
- Remove the old alipay icon (`alipay`). (https://github.com/activemerchant/payment_icons/pull/408)

- Rename the new alipay icon from `alipay_cn` to `alipay` to replace the old version. (https://github.com/activemerchant/payment_icons/pull/408)
