### PR TITLE
Improve contributing md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,10 +14,10 @@ To add a new payment method icon to this repository:
     - `wallets`
 
 4. Add an SVG icon to the `app/assets/images/payment_icons/` directory following the [guidelines for new icons](#guidelines-for-new-icons).
-5. Optimize your icon using [SVGO](https://jakearchibald.github.io/svgomg/) - instructions below.
+5. Optimize your icon using [SVGO](https://github.com/svg/svgo) (`v1.x.x`) - instructions below.
 
     ```
-    $ npm install -g svgo
+    $ npm install -g svgo@1.3.2
     $ svgo your-icon.svg --disable={removeUnknownsAndDefaults,removeTitle,cleanupIDs,removeViewBox}
     ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,7 +53,7 @@ All icon contributions must follow the guidelines below. The **markup** guidelin
   - Whenever possible, the background color does not use a gradient fill.
   - Transparent backgrounds will not be accepted.
 - Icons have a visible border to give them a consistent shape on pages whose backgrounds match that of the icon.
-  - Whenever possible, the border should be black (hex color `#000`) with a 0.07% opacity.
+  - Whenever possible, the border should be black (hex color `#000`) with a 7% opacity (`0.07`).
   - The border width must be 1px (pixel) thick.
   - The border must have a 2px radius (outside stroke).
 - Icons are clear and easy to read/understand


### PR DESCRIPTION
SVGO change inspired by personal experience of unintentionally trying to use SVGO `v2.x.x`.
<img width="801" alt="Screen Shot 2021-03-26 at 10 48 17" src="https://user-images.githubusercontent.com/1557529/112565925-608f4880-8e21-11eb-80c8-34a15d402533.png">

Opacity guideline inspired by https://github.com/activemerchant/payment_icons/pull/424#issuecomment-803901551.