### PR TITLE
Release v1.6.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    payment_icons (1.6.1)
+    payment_icons (1.6.2)
       frozen_record
       railties (>= 5.0)
       sassc-rails
@@ -72,9 +72,9 @@ GEM
     coderay (1.1.3)
     concurrent-ruby (1.1.8)
     crass (1.0.6)
-    dedup (0.1.2)
+    dedup (0.1.3)
     erubi (1.10.0)
-    ffi (1.13.1)
+    ffi (1.15.0)
     frozen_record (0.21.1)
       activemodel
       dedup

--- a/lib/payment_icons/version.rb
+++ b/lib/payment_icons/version.rb
@@ -1,3 +1,3 @@
 module PaymentIcons
-  VERSION = "1.6.1"
+  VERSION = "1.6.2"
 end


### PR DESCRIPTION
- Update Trustly icon ([#423](https://github.com/activemerchant/payment_icons/pull/423))
- Update MobilePay icon ([#424](https://github.com/activemerchant/payment_icons/pull/424))
- Add Alfamart, Indomaret, Dana, LinkAja, ShopeePay, BCA, BNI, BRI, Mandiri, Permata, BRI Direct Debit icons ([#425](https://github.com/activemerchant/payment_icons/pull/425))
- Add AliPay HK icon ([#427](https://github.com/activemerchant/payment_icons/pull/427))