### PR TITLE
Update Yahoo Mobile to Y!mobile

### DIFF
--- a/db/payment_icons.yml
+++ b/db/payment_icons.yml
@@ -732,7 +732,7 @@
   group: other
 -
   name: yahoo_mobile
-  label: Yahoo Mobile
+  label: Y!mobile
   group: other
 -
   name: mtn_mobile_money


### PR DESCRIPTION
> Would you correct the string of telco name "Yahoo mobile (in Japanese ヤフーモバイル)" to "Y!mobile (same in Japanese Y!mobile)"
> 
> --"Yahoo mobile" is a mobile web portal provided by "Yahoo Japan Corporation"
> --"Y!mobile" is a brand of the mobile network provided by "Softbank Cooperation"

Current name is inaccurate. We should update accordingly.

Resolve https://github.com/activemerchant/payment_icons/issues/459