### PR TITLE
Release v1.7.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    payment_icons (1.6.5)
+    payment_icons (1.7.0)
       frozen_record
       railties (>= 5.0)
       sassc-rails

--- a/lib/payment_icons/version.rb
+++ b/lib/payment_icons/version.rb
@@ -1,3 +1,3 @@
 module PaymentIcons
-  VERSION = "1.6.5"
+  VERSION = "1.7.0"
 end


### PR DESCRIPTION
⚠️ BREAKING | `yahoo_mobile` is now `ymobile`

- Add QRIS icon ([#453](https://github.com/activemerchant/payment_icons/pull/453))
- Add SAM icon ([#454](https://github.com/activemerchant/payment_icons/pull/454))
- Add AXS icon ([#455](https://github.com/activemerchant/payment_icons/pull/455))
- Renamed `yahoo_mobile` to `ymobile` ([#462](https://github.com/activemerchant/payment_icons/pull/462))

Second attempt after botched merged of https://github.com/activemerchant/payment_icons/pull/463.