### PR TITLE
Release v1.7.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    payment_icons (1.7.0)
+    payment_icons (1.7.1)
       frozen_record
       railties (>= 5.0)
       sassc-rails

--- a/lib/payment_icons/version.rb
+++ b/lib/payment_icons/version.rb
@@ -1,3 +1,3 @@
 module PaymentIcons
-  VERSION = "1.7.0"
+  VERSION = "1.7.1"
 end


### PR DESCRIPTION
- Added Facebook Pay icon ([#471](https://github.com/activemerchant/payment_icons/pull/471))