### PR TITLE
Update Bundler lock version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -163,4 +163,4 @@ DEPENDENCIES
   rails (>= 5.0)
 
 BUNDLED WITH
-   2.1.4
+   2.2.5


### PR DESCRIPTION
Bump Bundler to up-to-date, secure version.