### PR TITLE
Release v1.7.3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    payment_icons (1.7.2)
+    payment_icons (1.7.3)
       frozen_record
       railties (>= 5.0)
       sassc-rails

--- a/lib/payment_icons/version.rb
+++ b/lib/payment_icons/version.rb
@@ -1,3 +1,3 @@
 module PaymentIcons
-  VERSION = "1.7.2"
+  VERSION = "1.7.3"
 end


### PR DESCRIPTION
- Updated Facebook Pay icon ([#475](https://github.com/activemerchant/payment_icons/pull/475))