### PR TITLE
Update bundler to 2.2.22

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -163,4 +163,4 @@ DEPENDENCIES
   rails (>= 5.0)
 
 BUNDLED WITH
-   2.2.5
+   2.2.22


### PR DESCRIPTION
Need to update Bundler for 1. security reasons and 2. to fix deploy pipeline, blocking v1.7.4 release.