### PR TITLE
Revert "Release v1.7.4"

### DIFF
--- a/lib/payment_icons/version.rb
+++ b/lib/payment_icons/version.rb
@@ -1,3 +1,3 @@
 module PaymentIcons
-  VERSION = "1.7.4"
+  VERSION = "1.7.3"
 end


### PR DESCRIPTION
Reverts activemerchant/payment_icons#494 (release pipeline is broken)