### PR TITLE
Release v1.7.4

### DIFF
--- a/lib/payment_icons/version.rb
+++ b/lib/payment_icons/version.rb
@@ -1,3 +1,3 @@
 module PaymentIcons
-  VERSION = "1.7.3"
+  VERSION = "1.7.4"
 end


### PR DESCRIPTION
Attempt number 3 after fixing Bundler version in addition to other release pipeline issues
- https://github.com/activemerchant/payment_icons/pull/488
- https://github.com/activemerchant/payment_icons/pull/492
- https://github.com/activemerchant/payment_icons/pull/493
- PENDING FIX

Additions
- Added Farmlands icon ([#451](https://github.com/activemerchant/payment_icons/pull/451))
- Added Bread icon ([#479](https://github.com/activemerchant/payment_icons/pull/479))
- Added Nelo icon ([#480](https://github.com/activemerchant/payment_icons/pull/480))
- Added Affirm icon ([#483](https://github.com/activemerchant/payment_icons/pull/483))
- Added VVV Giftcard, Kunst en Cultuur Cadeaukaart, Nationale Bioscoop Bon, Nationale Entertainment Card, Podium Cadeaukaart, and Webshop Giftcard icons ([#485](https://github.com/activemerchant/payment_icons/pull/485))
- Added BillEase icon ([#487](https://github.com/activemerchant/payment_icons/pull/487))

Updates and maintenance
- Added new test and cleaned up 3 icons' markup ([#482](https://github.com/activemerchant/payment_icons/pull/482))
- Updated Kakao Pay icon ([#486](https://github.com/activemerchant/payment_icons/pull/486))
- Updated Payflex icon ([#490](https://github.com/activemerchant/payment_icons/pull/490))
- Upgraded bundler to v2.2.22 ([#493](https://github.com/activemerchant/payment_icons/pull/493))
- Set default Ruby to v2.7.4 ([#497](https://github.com/activemerchant/payment_icons/pull/497))
- Bumped a few gems ([#498](https://github.com/activemerchant/payment_icons/pull/498))

CC @tauthomas01 