### PR TITLE
Remove empty shipit.rubygems.yml

### DIFF
--- a/shipit.rubygems.yml
+++ b/shipit.rubygems.yml
@@ -1,1 +1,0 @@
-# using the default shipit config


### PR DESCRIPTION
Quick fix to remove empty `shipit` config.