### PR TITLE
Bundler 2.2.28

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -163,4 +163,4 @@ DEPENDENCIES
   rails (>= 5.0)
 
 BUNDLED WITH
-   2.2.22
+   2.2.28


### PR DESCRIPTION
Bump `bundler` to latest [2.2.28](https://github.com/rubygems/rubygems/blob/d01d6ca84011b05251b31d496f75f6aff8f677c4/bundler/CHANGELOG.md#2228-september-22-2021).