### PR TITLE
Release v1.7.6

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    payment_icons (1.7.5)
+    payment_icons (1.7.6)
       frozen_record
       railties (>= 5.0)
       sassc-rails

--- a/lib/payment_icons/version.rb
+++ b/lib/payment_icons/version.rb
@@ -1,3 +1,3 @@
 module PaymentIcons
-  VERSION = "1.7.5"
+  VERSION = "1.7.6"
 end


### PR DESCRIPTION
- Added Flexiti icon ([#509](https://github.com/activemerchant/payment_icons/pull/509))
- Fixed Swish icon ([#512](https://github.com/activemerchant/payment_icons/pull/512))
- Added TrueMoney Pay icon ([#514](https://github.com/activemerchant/payment_icons/pull/514))
- Set default Ruby to [2.7.5](https://www.ruby-lang.org/en/news/2021/11/24/ruby-2-7-5-released/) ([#518](https://github.com/activemerchant/payment_icons/pull/518))

Should also fix up `gift-card` internally re: https://github.com/activemerchant/payment_icons/pull/517.