### PR TITLE
Add payment_icons.yml entry for Gift Card

### DIFF
--- a/db/payment_icons.yml
+++ b/db/payment_icons.yml
@@ -1050,3 +1050,7 @@
   name: gmo-postpay
   label: GMO PostPay
   group: other
+-
+  name: gift-card
+  label: Gift Card
+  group: other


### PR DESCRIPTION
Add missing `payment_icons.yml` entry for Gift Card. Attempting to address https://github.com/activemerchant/payment_icons/pull/517#issuecomment-995591753.

CC @tauthomas01 