### PR TITLE
Add Ruby 3.1 to CI matrix

### DIFF
--- a/.github/workflows/ruby-ci.yml
+++ b/.github/workflows/ruby-ci.yml
@@ -21,6 +21,7 @@ jobs:
           - 2.6
           - 2.7
           - 3.0
+          - 3.1
         gemfile:
           - gemfiles/rails-5-0.gemfile
           - gemfiles/rails-latest-release.gemfile
@@ -31,6 +32,8 @@ jobs:
           - version: 2.6
             gemfile: gemfiles/rails-edge.gemfile
           - version: 3.0
+            gemfile: gemfiles/rails-5-0.gemfile
+          - version: 3.1
             gemfile: gemfiles/rails-5-0.gemfile
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Adding Ruby 3.1 to CI matrix. ~Will likely be failing for Rails latest until Rails 7.0.1 drops due to https://github.com/rails/rails/issues/43998.~

https://www.ruby-lang.org/en/news/2021/12/25/ruby-3-1-0-released/