### PR TITLE
Release v1.7.10

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    payment_icons (1.7.9)
+    payment_icons (1.7.10)
       frozen_record
       railties (>= 5.0)
       sassc-rails

--- a/lib/payment_icons/version.rb
+++ b/lib/payment_icons/version.rb
@@ -1,3 +1,3 @@
 module PaymentIcons
-  VERSION = "1.7.9"
+  VERSION = "1.7.10"
 end


### PR DESCRIPTION
- Updated GCash icon ([#513](https://github.com/activemerchant/payment_icons/pull/513))
- Added DirectPay icon ([#521](https://github.com/activemerchant/payment_icons/pull/521))
- Added LatitudePay and Genoapay icons ([#522](https://github.com/activemerchant/payment_icons/pull/522))