### PR TITLE
Clarify icon merge requirements

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,5 +4,6 @@
 - [ ] I have optimized the icon with [SVGO](https://jakearchibald.github.io/svgomg/)
 - [ ] I am confident that all icons are clear and easy to read/understand
 - [ ] I have provided a link to the brand icon’s brand guidelines whenever possible.
+- [ ] I recognize that if my icon is not approved by the Shopify Partners team it may not receive review nor merger.
 
 If this pull request is not adding new icons, you can remove this checklist.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-# 🛑 New icon contributions are not being accepted. 🙇‍♂️
-Please feel free to read up on [shopify.dev/apps/payments](https://shopify.dev/apps/payments) and/or reach out on the [developer forums](https://community.shopify.com/c/App-Partner-Platform/ct-p/appdev).
+## ⚠️ Only Shopify Partners team approved icons may be reviewed/merged ⚠️
+Please read more on [shopify.dev/apps/payments](https://shopify.dev/apps/payments) and/or reach out on the [developer forums](https://community.shopify.com/c/App-Partner-Platform/ct-p/appdev).
 
 # Payment Icons
 


### PR DESCRIPTION
Attempting to clarify the requirement that icons be approved by the Shopify Partners team before they will be reviewed and merged by the maintainers of this repository・gem.

Closes https://github.com/activemerchant/payment_icons/pull/550 (supersedes)