### PR TITLE
Remove unused codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,0 @@
-# Please keep these lines sorted alphabetically.
-# Wildcards can work in unexpected ways.  https://help.github.com/articles/about-codeowners/
-
-app/assets/images/ @activemerchant/designers


### PR DESCRIPTION
Remove the unused codeowners file which apparently has been trying to assign a non-existent `designers` team to PRs this while time. Recent pre-PR-publish GitHub change that show which teams will be requested for review brought this to my attention.
<img width="322" alt="Screen Shot 2022-03-02 at 14 46 14" src="https://user-images.githubusercontent.com/1557529/156302824-5e8dc8cc-b170-4144-8380-700da61bbd78.png">