### PR TITLE
Update Bundler from 2.3.3 to 2.3.9

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -188,4 +188,4 @@ DEPENDENCIES
   rails (>= 5.0)
 
 BUNDLED WITH
-   2.3.3
+   2.3.9


### PR DESCRIPTION
Bringing Bundler up to date before next release.

https://github.com/rubygems/rubygems/blob/7f90c0083aff30ec4b7625af6fc632cdd90dcbb2/bundler/CHANGELOG.md#239-march-9-2022