### PR TITLE
Bump gems

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -161,7 +161,7 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
-    sprockets (4.0.2)
+    sprockets (4.0.3)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-rails (3.4.2)


### PR DESCRIPTION
Bringing gems (just sprockets this time) up to date before next release.

https://github.com/rails/sprockets/blob/58cca17aa447fcee17703e4ab4dbfaab630e7ed4/CHANGELOG.md#403