### PR TITLE
[Security] Bump rack from 2.2.3 to 2.2.3.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -121,7 +121,7 @@ GEM
       coderay (~> 1.1)
       method_source (~> 1.0)
     racc (1.6.0)
-    rack (2.2.3)
+    rack (2.2.3.1)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (7.0.3)


### PR DESCRIPTION
Resolve the following security advisories.
- https://github.com/activemerchant/payment_icons/security/dependabot/8
- https://github.com/activemerchant/payment_icons/security/dependabot/9