### PR TITLE
Bump gems

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -98,7 +98,7 @@ GEM
     method_source (1.0.0)
     mini_mime (1.1.2)
     mini_portile2 (2.8.0)
-    minitest (5.16.0)
+    minitest (5.16.1)
     net-imap (0.2.3)
       digest
       net-protocol
@@ -122,8 +122,8 @@ GEM
       method_source (~> 1.0)
     racc (1.6.0)
     rack (2.2.3.1)
-    rack-test (1.1.0)
-      rack (>= 1.0, < 3)
+    rack-test (2.0.0)
+      rack (>= 1.3)
     rails (7.0.3)
       actioncable (= 7.0.3)
       actionmailbox (= 7.0.3)
@@ -159,7 +159,7 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
-    sprockets (4.0.3)
+    sprockets (4.1.0)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-rails (3.4.2)


### PR DESCRIPTION
Bump gems via `bundle update` to prepare for v1.7.15 release.