### PR TITLE
Remove spaces from payment_icons.yml

### DIFF
--- a/db/payment_icons.yml
+++ b/db/payment_icons.yml
@@ -1337,7 +1337,7 @@
 -
   name: uangme
   label: UangMe
-  group: other 
+  group: other
 -
   name: grailpay
   label: GrailPay
@@ -1370,7 +1370,7 @@
   name: kredivo
   label: Kredivo
   group: other
-- 
+-
   name: tandym-payment
   label: Tandym Payment
   group: other


### PR DESCRIPTION
Prevent diffs like the following by shipping these space removals now.
<img width="646" alt="Screen Shot 2022-07-21 at 10 00 05" src="https://user-images.githubusercontent.com/1557529/180107399-2e57e592-c99a-4315-8fcb-1236a99d146c.png">