### PR TITLE
Remove space from payment_icons.yml

### DIFF
--- a/db/payment_icons.yml
+++ b/db/payment_icons.yml
@@ -1274,7 +1274,7 @@
   name: aplazo
   label: Aplazo
   group: other
-- 
+-
   name: paybylink
   label: Pay By Link
   group: other


### PR DESCRIPTION
Simply removing an unnecessary space from the `payment_icons.yml` file.