### PR TITLE
Only allow lowercase alpha characters in the name

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,6 +59,9 @@ All icon contributions must follow the guidelines below. The **markup** guidelin
 - Icons are clear and easy to read/understand
 - Whenever possible, provide a link to the brand icon’s brand guidelines (e.g. [Google Pay](https://developers.google.com/pay/api/web/guides/brand-guidelines))
 
+### Name
+- The name entered in `db/payment_icons.yml` must be lowercase alpha characters only.
+
 ### File
 - The name of the SVG must be the same as the `name` entered in `db/payment_icons.yml`
 

--- a/test/payment_icon_name_shitlist.rb
+++ b/test/payment_icon_name_shitlist.rb
@@ -1,0 +1,96 @@
+# Dated: 9th Nov 2022
+# Author: Rahil Virani
+#
+# The special characters in the name has caused a lot of issues in the past
+# to seamlessly deploy the new icons. This is casued by
+# repositories using different seperators for their local list of acceptable icons
+# i.e. Jascript uses camelcase vs. others using underscore. The value of the name
+# also reflects the name of the svg file and certain attributes in the svg, it is becoming
+# harder to keep them in sync in multiple repositories.
+#
+# Decision: Moving forward we should only accept lower case alpha characters in the name
+class PaymentIconNameShitlist
+  class << self
+    LIST_OF_EXEMPTED_NAMES = %w(
+      american_express
+      diners_club
+      cartes_bancaires
+      ing_homepay
+      bitcoin_cash
+      kbc_cbc
+      sepa_bank_transfer
+      google_pay
+      google_wallet
+      payfast_instant_eft
+      airtel_money
+      ola_money
+      danske_bank
+      klarna-pay-now
+      klarna-pay-later
+      klarna-slice-it
+      przelew24
+      collector_bank
+      apple_pay
+      shopify_pay
+      paymark_online_eftpos
+      esr_paymentslip_switzerland
+      eft_secure
+      in3
+      v_pay
+      maybankm2u
+      publicbank_pbe
+      bc_card
+      hana_card
+      hyundai_card
+      kb_card
+      lotte_card
+      nh_card
+      samsung_card
+      shinhan_card
+      kakao_pay
+      naver_pay
+      samsung_pay
+      afterpay_paynl_version
+      line_pay
+      rakuten_pay
+      pay_easy
+      mtn_mobile_money
+      airteltigo_mobile_money
+      d_barai
+      docomo_barai
+      pay_pay
+      au_kantan_kessai
+      latitude_creditline_au
+      latitude_gem_au
+      latitude_gem_nz
+      latitude_go_au
+      bogus_app_coin
+      postfinance_card
+      postfinance_efinance
+      alipay_hk
+      qr_promptpay
+      bri_direct_debit
+      facebook_pay
+      vvv_giftcard
+      checkout_finance
+      n26
+      echelon_financing
+      acima_leasing
+      synchrony_pay
+      truemoney_pay
+      gmo-postpay
+      gift-card
+      pop-pankki
+      s-pankki
+      snap_checkout
+      sveab2binvoice
+      sveab2bfaktura
+      billink_method
+      sveaOstukonto
+      sveaCreditAccount
+    )
+    def exempted
+      LIST_OF_EXEMPTED_NAMES
+    end
+  end
+end

--- a/test/unit/payment_icon_test.rb
+++ b/test/unit/payment_icon_test.rb
@@ -1,4 +1,6 @@
 require 'test_helper'
+require 'pry'
+require 'payment_icon_name_shitlist'
 
 class PaymentIconTest < ActiveSupport::TestCase
 
@@ -125,6 +127,14 @@ class PaymentIconTest < ActiveSupport::TestCase
     SVG_PAYMENT_TYPES.each do |payment_type, svg|
       error_message = "The '#{payment_type}' SVG file should contain a single line of markup, optionally terminated by an empty line"
       assert svg.lines.count == 1 || (svg.lines.count == 2 && svg.lines[1] == ''), error_message
+    end
+  end
+
+  test 'Payment icon name contains alpha characters only' do
+    shitlist_exempted_names = PaymentIconNameShitlist.exempted
+    PaymentIcon.all.each do |icon|
+      next if shitlist_exempted_names.include?(icon.name)
+      assert_match /^[a-z]+$/, icon.name, "#{icon.name} contains non-alpha character"
     end
   end
 end


### PR DESCRIPTION
## Why are you trying to do?
Enforcing the name to only be in a lowercase alpha characters format because it eliminates the process of [normalizing icons ](https://github.com/activemerchant/payment_icons/pull/736) before the release.

Normalizing icons is a new task that a release captain performs to change all names to a lowercase and remove any delimiter between the characters. We noticed that the repositories have their strategies to delimit names i.e. `underscore` or `camelize` to declare the local copy of the supported icons and match them from the data retrieved from API which sometimes does not match. This is adding overhead on the release captain and also ambiguity in some of the special case scenarios when there is an integer in the name.

Having this change will eliminate the need for normalizing icons and prevents contributors to suggest a name that includes anything except alpha characters

## How is the change being implemented
I added a test to prevent any characters except alphabets in the name and created a shit list that will continue to grandfather the older icons.

I also added a line item in a contribution guide so that the authors are aware of the change

## Why can't we change all names to match this format
The older icon names are being used in all the repositories and changing them will be considered as a breaking change.