### PR TITLE
Bump to v1.7.20

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    payment_icons (1.7.19)
+    payment_icons (1.7.20)
       frozen_record
       railties (>= 5.0)
       sassc-rails

--- a/lib/payment_icons/version.rb
+++ b/lib/payment_icons/version.rb
@@ -1,3 +1,3 @@
 module PaymentIcons
-  VERSION = "1.7.19"
+  VERSION = "1.7.20"
 end


### PR DESCRIPTION
`v1.7.19` was not updated here: https://rubygems.org/gems/payment_icons/

updating a new tag.