### PR TITLE
Add support for bump gem so we can easily bump gem versions

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,6 +75,7 @@ GEM
       minitest (>= 5.1)
       tzinfo (~> 2.0)
     builder (3.2.4)
+    bump (0.10.0)
     coderay (1.1.3)
     concurrent-ruby (1.2.0)
     crass (1.0.6)
@@ -176,6 +177,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  bump
   payment_icons!
   pry
   rails (>= 5.0)

--- a/README.md
+++ b/README.md
@@ -51,11 +51,7 @@ To create a new release:
 - `git checkout master` to get back to master branch
 - `git fetch --tags --force` to refresh tags
 - `git pull origin master` to pull latest changes to your local environment
-- Change version in `lib/payment_icons/version.rb`. Normally a patch version bump is enough. Otherwise, see https://semver.org/.
-- Run `bundle install`, which should update the `Gemfile.lock` `payment_icons` version
-- Commit the changes: `git commit -m 'Bump to <version>'`
-- `git tag -a v<version>`
-  - If prompted, make a comment about this version bump. i.e. "Adds icons X and Y"
+- Run `bump patch --tag --tag-prefix v --commit-message release`. This will create a new commit that includes a version bump and a new tag.
 - `git push --tags origin master`
 - Contact a maintainer in Shopify to release the new version via ShipIt.
 

--- a/payment_icons.gemspec
+++ b/payment_icons.gemspec
@@ -25,4 +25,5 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency('rails', '>= 5.0')
   s.add_development_dependency('pry')
+  s.add_development_dependency('bump')
 end


### PR DESCRIPTION
## What are you trying to change?

I'm adding a gem that should make the process for bump the version and release a new tag easily, like:

`bump patch --tag --tag-prefix v --commit-message release`

It is also nice that we don't need to care about finding the current version and updating it, the gems knows how to do it =)

This will substitute the follow steps:

1) Change version in lib/payment_icons/version.rb. Normally a patch version bump is enough. Otherwise, see https://semver.org/.
2) Run bundle install, which should update the Gemfile.lock payment_icons version
3) Commit the changes: git commit -m 'Bump to <version>'
4) git tag -a v<version> If prompted, make a comment about this version bump. i.e. "Adds icons X and Y"

Finally, it will look like this:

<img width="884" alt="Screenshot 2023-02-17 at 12 10 07" src="https://user-images.githubusercontent.com/411301/219719139-bdc2faa2-22ca-4b9e-a32d-a96e972c8803.png">