### PR TITLE
Remove Rails edge for Ruby 2.7

### DIFF
--- a/.github/workflows/ruby-ci.yml
+++ b/.github/workflows/ruby-ci.yml
@@ -29,6 +29,8 @@ jobs:
         exclude:
           - version: 2.6
             gemfile: gemfiles/rails-edge.gemfile
+          - version: 2.7
+            gemfile: gemfiles/rails-edge.gemfile
           - version: 3.0
             gemfile: gemfiles/rails-6-0.gemfile
           - version: 3.1


### PR DESCRIPTION
Add Ruby 2.7 to exclude Rails edge similarly as [it was done in the past for Ruby 2.6](https://github.com/activemerchant/payment_icons/pull/404) to see if this resolves CI issues we've been getting ([example failure](https://github.com/activemerchant/payment_icons/pull/1120))


```ruby
> bundle install
/opt/hostedtoolcache/Ruby/2.7.8/x64/bin/bundle config --local path /home/runner/work/payment_icons/payment_icons/vendor/bundle
/opt/hostedtoolcache/Ruby/2.7.8/x64/bin/bundle lock
Fetching https://github.com/rails/rails.git
Fetching gem metadata from https://rubygems.org/...........
Resolving dependencies...
Could not find compatible versions

Because every version of rails depends on Ruby >= 3.1.0
  and rails-edge.gemfile depends on rails >= 0,
  Ruby >= 3.1.0 is required.
So, because current Ruby version is = 2.7.8,
  version solving has failed.
```