### PR TITLE
Updating Gemfile to use 1.3.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 source 'https://rubygems.org'
+gem 'concurrent-ruby', '< 1.3.4'
 
 gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,7 +86,7 @@ GEM
     builder (3.3.0)
     bump (0.10.0)
     coderay (1.1.3)
-    concurrent-ruby (1.3.4)
+    concurrent-ruby (1.3.3)
     connection_pool (2.5.0)
     crass (1.0.6)
     date (3.4.1)
@@ -97,13 +97,14 @@ GEM
       activemodel
     globalid (1.2.1)
       activesupport (>= 6.1)
-    i18n (1.14.6)
+    i18n (1.14.7)
       concurrent-ruby (~> 1.0)
     io-console (0.8.0)
-    irb (1.14.3)
+    irb (1.15.1)
+      pp (>= 0.6.0)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
-    logger (1.6.4)
+    logger (1.6.5)
     loofah (2.24.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
@@ -127,13 +128,16 @@ GEM
     net-smtp (0.5.0)
       net-protocol
     nio4r (2.7.4)
-    nokogiri (1.18.1)
+    nokogiri (1.18.2)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
+    pp (0.6.2)
+      prettyprint
+    prettyprint (0.2.0)
     pry (0.15.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
-    psych (5.2.2)
+    psych (5.2.3)
       date
       stringio
     racc (1.8.1)
@@ -175,7 +179,7 @@ GEM
       thor (~> 1.0, >= 1.2.2)
       zeitwerk (~> 2.6)
     rake (13.2.1)
-    rdoc (6.10.0)
+    rdoc (6.11.0)
       psych (>= 4.0.0)
     reline (0.6.0)
       io-console (~> 0.5)
@@ -197,7 +201,7 @@ GEM
       sprockets (>= 3.0.0)
     stringio (3.1.2)
     thor (1.3.2)
-    tilt (2.5.0)
+    tilt (2.6.0)
     timeout (0.4.3)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
@@ -214,6 +218,7 @@ PLATFORMS
 
 DEPENDENCIES
   bump
+  concurrent-ruby (< 1.3.4)
   payment_icons!
   pry
   rails (>= 5.0)


### PR DESCRIPTION
Ruby released a broken gem for concurrent-ruby and haven't had time to patch all the versions yet. 
 This was introduced in the 1.3.5 Ruby Concurrent release. In the meantime, we are proposing that we downgrade the version referenced in the Gemfile so that our PR's will pass their tests/validation.