### PR TITLE
Direct contributors to Test step output instead of Summary tab

### DIFF
--- a/.github/workflows/ruby-ci.yml
+++ b/.github/workflows/ruby-ci.yml
@@ -117,7 +117,15 @@ jobs:
       - name: Fail if tests failed
         if: steps.test.outcome == 'failure'
         run: |
-          echo "Tests failed. Click the 'Summary' tab on this workflow run for a detailed validation report."
+          echo "::error::Tests failed. Expand the 'Test' step above to see the full failure output."
+          if [ -f test_output.log ]; then
+            echo ""
+            echo "========== Failure Summary =========="
+            grep -A 2 'Failure\|Error\|FAIL\|expected.*but\|icon.*not found' test_output.log || true
+            echo "====================================="
+            echo ""
+            echo "For the complete output, expand the 'Test' step above."
+          fi
           exit 1
 
   # Runs once (not per matrix combination) to check PR file scope.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ To add a new payment method icon to this repository:
 When you open a pull request:
 
 - ✅ **Automated Tests Run** — All 20 validation tests check your icon
-- ✅ **Instant Feedback** — If tests fail, click the failed check, then the **"Summary"** tab to see a detailed validation report showing exactly what needs fixing
+- ✅ **Instant Feedback** — If tests fail, click the failed check, then expand the **"Test"** step to see exactly what needs fixing
 - ⚠️ **File Scope Check** — If your PR changes files outside the expected scope, a warning annotation appears on the check (see [below](#file-scope-check))
 
 ---


### PR DESCRIPTION
## Problem

The CI failure message currently tells contributors to click the **Summary** tab to see validation details. However, the Summary tab doesn't always reliably surface the step summary content, which causes confusion for external contributors.

## Changes

- **`.github/workflows/ruby-ci.yml`**: Updated the "Fail if tests failed" step to:
  - Use `::error::` annotation for prominent red error in the GitHub Actions UI
  - Direct contributors to expand the **Test** step (where the full output already lives)
  - Extract and print a failure summary inline so key errors are immediately visible
- **`CONTRIBUTING.md`**: Updated the "Instant Feedback" guidance to match

## Permission safety

All changes are local to the runner (stdout, file reads). No API calls or write permissions required — safe for forked PRs.